### PR TITLE
fpm: Build all DEBs for multiarch (arch <all>)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 tmp/
-repositories/ubuntu/networking-bgpvpn-config_*_amd64.deb
-repositories/ubuntu/python-networking-bgpvpn_*_all.deb
+repositories/ubuntu/networking-bgpvpn-config_*.deb
+repositories/ubuntu/python-networking-bgpvpn_*.deb
 .build/

--- a/pre_build_hook
+++ b/pre_build_hook
@@ -27,19 +27,22 @@ function build_pkg {
   case $1 in
     ubuntu)
       pushd "${DIR}/repositories/${1}/"
-      fpm --force -s python -t deb -m 'mskalski@mirantis.com' --python-disable-dependency oslo.config ${TMP_DIR}/networking-bgpvpn/setup.py
+      fpm --architecture all --force -s python -t deb -m 'mskalski@mirantis.com' \
+        --python-disable-dependency oslo.config ${TMP_DIR}/networking-bgpvpn/setup.py
 
       # fpm -C is buggy https://github.com/jordansissel/fpm/issues/818
       # so we have to change the rootdir manually
       pushd ${TMP_DIR}/networking-bgpvpn/
-      fpm --force -s dir -t deb -m 'nikolas.hermanns@ericsson.com' --config-files etc  -n networking-bgpvpn-config -v 1.0 etc
-      mv networking-bgpvpn-config_*_amd64.deb ${DIR}/repositories/${1}/
+      fpm --architecture all --force -s dir -t deb -m 'nikolas.hermanns@ericsson.com' \
+        --config-files etc  -n networking-bgpvpn-config -v 1.0 etc
+      mv networking-bgpvpn-config_*.deb ${DIR}/repositories/${1}/
       popd
 
       # Networking odl is needed cause it is a dependencie. There is no way yet to make
       # the bgpvpn installation waiting for the ODL installation, when ODL installation
       # is optional: http://permalink.gmane.org/gmane.comp.cloud.openstack.devel/63333
-      fpm --force -s python -t deb -m 'nikolas.hermanns@ericsson.com' --no-python-dependencies -d python-pbr -d python-babel -d python-neutron ${TMP_DIR}/networking_odl/setup.py
+      fpm --architecture all --force -s python -t deb -m 'nikolas.hermanns@ericsson.com' \
+        --no-python-dependencies -d python-pbr -d python-babel -d python-neutron ${TMP_DIR}/networking_odl/setup.py
 
       popd
       ;;


### PR DESCRIPTION
Apart from one small hardcoded check on Fedora for java version,
most code is arch-independant (python).

fpm defaults to arch <all> or the native one when building the DEB
packages, so use an explicit set for arch <all> in all fpm builds.

TODO:
 Extend check for `uname -m` result for aarch64 and other platforms
 in <networking_odl/devstack/setup_java.sh>.

Signed-off-by: Alexandru Avadanii Alexandru.Avadanii@enea.com
